### PR TITLE
Work for milestone 9.2

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -12,6 +12,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from mock import patch
 import unittest2
 
 #from neutron import context
@@ -19,6 +20,12 @@ import unittest2
 
 class TestBase(unittest2.TestCase):
     '''Class to decide which unit test class to inherit from uniformly.'''
+
+    def create_patch(self, name, func=None):
+        patcher = patch(name)
+        thing = patcher.start()
+        self.addCleanup(patcher.stop)
+        return thing
 
     def setUp(self):
         super(TestBase, self).setUp()

--- a/tests/test_try_context.py
+++ b/tests/test_try_context.py
@@ -13,198 +13,90 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 import mock
-from mock import patch
 from wafflehaus.try_context import context_filter
 from tests import test_base
-
-CTX = None
-try:
-    from neutron import context
-    CTX = context
-except ImportError as e:
-    pass
+import webob.exc
 
 
-class TestContextClass(object):
-    pass
+class TestContextClass(context_filter.BaseContextStrategy):
+    def __init__(self, key):
+        super(TestContextClass, self).__init__(key)
+        self._mockme()
+
+    def _mockme(self):
+        """Exists because one can't mock __init__."""
+        pass
 
 
 class TestTryContext(test_base.TestBase):
+
     def setUp(self):
         super(TestTryContext, self).setUp()
         self.app = mock.Mock()
         self.app.return_value = "OK"
         self.start_response = mock.Mock()
         self.test_cls = "tests.test_try_context.TestContextClass"
+        self.context_init = self.create_patch(self.test_cls + '._mockme')
 
-        self.req = {'REQUEST_METHOD': 'HEAD',
-                    'X_USER_ID': '12345', }
-
-        self.local_conf = {"context_class": self.test_cls,
+        self.strat_test = {"context_strategy": self.test_cls,
                            "context_key": "context.test", }
 
-        self.strat_neutron = {"context_strategy": "neutron"}
-        self.strat_none = {"context_strategy": "none"}
-        self.strat_test = {"context_strategy": "test"}
+        self.strat_testing = {"context_strategy": self.test_cls,
+                              "context_key": "context.test",
+                              "testing": "true"}
+
+        self.unknown = {"context_strategy": "unknown.class",
+                        "context_key": "context.test", }
+
+        self.unknown_testing = {"context_strategy": "unknown.class",
+                                "context_key": "context.test",
+                                "testing": "true"}
         self.get_admin_mock = mock.Mock()
         self.get_admin_mock.return_value = ['admin']
 
     def test_create_strategy_test(self):
         """This is a test strategy to see if this thing works"""
         result = context_filter.filter_factory(self.strat_test)(self.app)
-        self.assertTrue(isinstance(result, context_filter.TestContextFilter))
-        self.assertEqual('OK', result(self.req, self.start_response))
+        self.assertTrue(isinstance(result, context_filter.ContextFilter))
+        resp = result.__call__.request('/something', method='HEAD')
+        self.assertEqual(self.app, resp)
+        self.assertEqual(1, self.context_init.call_count)
+        self.assertTrue(isinstance(result, context_filter.ContextFilter))
+        """Should be 1 because of a new instance."""
+        self.assertEqual(1, self.context_init.call_count)
+
+    def test_create_strategy_test_noop_testing(self):
+        """This is a test strategy to see if this thing works"""
+        result = context_filter.filter_factory(self.strat_test)(self.app)
+        self.assertTrue(isinstance(result, context_filter.ContextFilter))
+        resp = result.__call__.request('/something', method='HEAD')
+        self.assertEqual(self.app, resp)
+        self.assertEqual(1, self.context_init.call_count)
+        self.assertTrue(isinstance(result, context_filter.ContextFilter))
+        """Should be 1 because of a new instance."""
+        self.assertEqual(1, self.context_init.call_count)
 
     def test_create_strategy_none(self):
         """The none strategy simply is a noop."""
-        result = context_filter.filter_factory(self.strat_none)(self.app)
+        result = context_filter.filter_factory({})(self.app)
         self.assertIsNotNone(result)
-        self.assertTrue(not isinstance(result, context_filter.ContextFilter))
-        self.assertEqual('OK', result(self.req, self.start_response))
-
-    def test_create_strategy_neutron(self):
-        """Attempt to create the neutron strategy if it is installed. This
-        will probably never run inside of tox because test-requirements are
-        weird."""
-        if not CTX:
-            self.skipTest("Neutron not installed. ")
-        result = context_filter.filter_factory(self.strat_neutron)(self.app)
-        self.assertIsNotNone(result)
-        self.assertTrue(isinstance(result,
-                                   context_filter.NeutronContextFilter))
-        self.assertFalse('neutron.context' in self.req)
-        headers = {'Content-Type': 'application/json',
-                   'X_USER_ID': 'derp', }
-        with patch('neutron.policy.get_admin_roles',
-                   self.get_admin_mock) as mocked_get:
-            resp = result.__call__.request('/', method='HEAD', headers=headers)
-        self.assertEqual(self.app, resp)
-        self.assertIsNotNone(result.context)
-        self.assertTrue(mocked_get.called)
-
-    def test_create_strategy_neutron_no_user(self):
-        """Attempt to create the neutron strategy if it is installed. This
-        will probably never run inside of tox because test-requirements are
-        weird."""
-        if not CTX:
-            self.skipTest("Neutron not installed. ")
-        result = context_filter.filter_factory(self.strat_neutron)(self.app)
-        self.assertIsNotNone(result)
-        self.assertTrue(isinstance(result,
-                                   context_filter.NeutronContextFilter))
-        self.assertFalse('neutron.context' in self.req)
-        headers = {'Content-Type': 'application/json', }
-        with patch('neutron.policy.get_admin_roles',
-                   self.get_admin_mock):
-            resp = result.__call__.request('/', method='HEAD', headers=headers)
-        self.assertIsNotNone(result.context)
+        resp = result.__call__.request('/something', method='HEAD')
+        self.assertTrue(isinstance(result, context_filter.ContextFilter))
         self.assertEqual(self.app, resp)
 
-    def test_create_strategy_neutron_with_no_roles(self):
-        """Attempt to create the neutron strategy if it is installed. This
-        will probably never run inside of tox because test-requirements are
-        weird."""
-        if not CTX:
-            self.skipTest("Neutron not installed. ")
-        result = context_filter.filter_factory(self.strat_neutron)(self.app)
+    def test_create_strategy_unknown_should_500(self):
+        """The none strategy simply is a noop."""
+        result = context_filter.filter_factory(self.unknown)(self.app)
         self.assertIsNotNone(result)
-        self.assertTrue(isinstance(result,
-                                   context_filter.NeutronContextFilter))
-        self.assertFalse('neutron.context' in self.req)
-        headers = {'Content-Type': 'application/json',
-                   'X_ROLES': None, }
-        with patch('neutron.policy.get_admin_roles',
-                   self.get_admin_mock):
-            resp = result.__call__.request('/', method='HEAD', headers=headers)
-        self.assertEqual(self.app, resp)
-        self.assertIsNotNone(result.context)
-        self.assertTrue(hasattr(result.context, 'roles'))
+        self.assertTrue(isinstance(result, context_filter.ContextFilter))
+        resp = result.__call__.request('/something', method='HEAD')
+        self.assertNotEqual(self.app, resp)
+        self.assertTrue(isinstance(resp, webob.exc.HTTPInternalServerError))
 
-    def test_create_strategy_neutron_with_empty_roles(self):
-        """Attempt to create the neutron strategy if it is installed. This
-        will probably never run inside of tox because test-requirements are
-        weird."""
-        if not CTX:
-            self.skipTest("Neutron not installed. ")
-        result = context_filter.filter_factory(self.strat_neutron)(self.app)
+    def test_create_strategy_unknown_should_500_noop_testing(self):
+        """The none strategy simply is a noop."""
+        result = context_filter.filter_factory(self.unknown_testing)(self.app)
         self.assertIsNotNone(result)
-        self.assertTrue(isinstance(result,
-                                   context_filter.NeutronContextFilter))
-        self.assertFalse('neutron.context' in self.req)
-        headers = {'Content-Type': 'application/json',
-                   'X_ROLES': '', }
-        with patch('neutron.policy.get_admin_roles',
-                   self.get_admin_mock):
-            resp = result.__call__.request('/', method='HEAD', headers=headers)
+        self.assertTrue(isinstance(result, context_filter.ContextFilter))
+        resp = result.__call__.request('/something', method='HEAD')
         self.assertEqual(self.app, resp)
-        self.assertIsNotNone(result.context)
-        self.assertTrue(hasattr(result.context, 'roles'))
-
-    def test_create_strategy_neutron_with_role(self):
-        """Attempt to create the neutron strategy if it is installed. This
-        will probably never run inside of tox because test-requirements are
-        weird."""
-        if not CTX:
-            self.skipTest("Neutron not installed. ")
-        result = context_filter.filter_factory(self.strat_neutron)(self.app)
-        self.assertIsNotNone(result)
-        self.assertTrue(isinstance(result,
-                                   context_filter.NeutronContextFilter))
-        self.assertFalse('neutron.context' in self.req)
-        headers = {'Content-Type': 'application/json',
-                   'X_ROLES': 'testrole', }
-        with patch('neutron.policy.get_admin_roles',
-                   self.get_admin_mock):
-            resp = result.__call__.request('/', method='HEAD', headers=headers)
-        self.assertEqual(self.app, resp)
-        self.assertIsNotNone(result.context)
-        self.assertTrue(hasattr(result.context, 'roles'))
-        self.assertTrue('testrole' in result.context.roles)
-
-    def test_create_strategy_neutron_with_roles(self):
-        """Attempt to create the neutron strategy if it is installed. This
-        will probably never run inside of tox because test-requirements are
-        weird."""
-        if not CTX:
-            self.skipTest("Neutron not installed. ")
-        result = context_filter.filter_factory(self.strat_neutron)(self.app)
-        self.assertIsNotNone(result)
-        self.assertTrue(isinstance(result,
-                                   context_filter.NeutronContextFilter))
-        self.assertFalse('neutron.context' in self.req)
-        headers = {'Content-Type': 'application/json',
-                   'X_ROLES': 'testrole, testrole2', }
-        with patch('neutron.policy.get_admin_roles',
-                   self.get_admin_mock):
-            resp = result.__call__.request('/', method='HEAD', headers=headers)
-        self.assertEqual(self.app, resp)
-        self.assertIsNotNone(result.context)
-        self.assertTrue(hasattr(result.context, 'roles'))
-        self.assertTrue('testrole' in result.context.roles)
-        self.assertTrue('testrole2' in result.context.roles)
-
-    def test_create_strategy_neutron_appends_to_admin_role(self):
-        """Attempt to create the neutron strategy if it is installed. This
-        will probably never run inside of tox because test-requirements are
-        weird."""
-        if not CTX:
-            self.skipTest("Neutron not installed. ")
-        result = context_filter.filter_factory(self.strat_neutron)(self.app)
-        self.assertIsNotNone(result)
-        self.assertTrue(isinstance(result,
-                                   context_filter.NeutronContextFilter))
-        self.assertFalse('neutron.context' in self.req)
-        headers = {'Content-Type': 'application/json',
-                   'X_ROLES': 'testrole, testrole2', }
-        with patch('neutron.policy.get_admin_roles',
-                   self.get_admin_mock):
-            resp = result.__call__.request('/', method='HEAD', headers=headers)
-        self.assertEqual(self.app, resp)
-        self.assertIsNotNone(result.context)
-        self.assertTrue(hasattr(result.context, 'roles'))
-        self.assertTrue('testrole' in result.context.roles)
-        self.assertTrue('testrole2' in result.context.roles)
-        set_a = set(['testrole', 'testrole2'])
-        set_b = set(result.context.roles)
-        set_result = set_b - set_a
-        self.assertTrue(set_a not in set_result)

--- a/tests/test_wafflehaus_base.py
+++ b/tests/test_wafflehaus_base.py
@@ -1,0 +1,35 @@
+# Copyright 2013 Openstack Foundation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import mock
+from tests import test_base
+
+from wafflehaus.base import WafflehausBase
+
+
+class TestWafflehausBase(test_base.TestBase):
+    def setUp(self):
+        self.app = mock.Mock()
+
+    def test_create_default_instance(self):
+        base = WafflehausBase(self.app, {})
+        self.assertIsNotNone(base)
+        self.assertFalse(base.testing)
+        self.assertEqual(base.app, self.app)
+
+    def test_create_default_instance_with_testing(self):
+        base = WafflehausBase(self.app, {'testing': 'true'})
+        self.assertIsNotNone(base)
+        self.assertTrue(base.testing)
+        self.assertEqual(base.app, self.app)

--- a/wafflehaus/base.py
+++ b/wafflehaus/base.py
@@ -1,0 +1,26 @@
+# Copyright 2013 Openstack Foundation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import logging
+
+
+class WafflehausBase(object):
+
+    def __init__(self, app, conf):
+        self.conf = conf
+        self.app = app
+        logname = __name__
+        self.log = logging.getLogger(conf.get('log_name', logname))
+        self.testing = (conf.get('testing') in
+                        (True, 'true', 't', '1', 'on', 'yes', 'y'))

--- a/wafflehaus/dns_filter/README.rst
+++ b/wafflehaus/dns_filter/README.rst
@@ -40,6 +40,8 @@ This will pass any request that resolves to a domain that ends with
 *mydomain.com* (such as wwww.mydomain.com, mydomain.com,
 secure.sub.mydomain.com, etc.).
 
+The whitelist configuration option is a space delimited list.
+
 Example Positive Testing Config
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -48,6 +50,19 @@ filter is working::
 
     [filter:dns_filter]
     paste.filter_factory = wafflehaus.dns_filter.whitelist:filter_factory
-    whitelist = mydomain.com
+    whitelist = mydomain.com random.org
     testing = true
     testing_remote_addr = 123.123.123.123 # a valid IP for whitelist
+
+Dealing with Load Balanced Requests with X-Forwarded-For
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If your service is behind a load balancer, as most cloudy things are, you will
+need to ensure that the load balancer provides an X-Forwarded-For header to
+this service.
+
+If your service is behind a load balancer and you do not desire to read the
+X-Forwarded-For header, you may set the configuration option `ignore_forwarded`
+to true and it will not use that header.
+
+This filter will use the first IP address in the X-Forwarded-For list.

--- a/wafflehaus/payload_filter/unset_key.py
+++ b/wafflehaus/payload_filter/unset_key.py
@@ -12,26 +12,20 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
-import logging
-
 import webob.dec
 import webob.exc
 
+import wafflehaus.base
 import wafflehaus.payload_filter as pf
 import wafflehaus.resource_filter as rf
 
 
-class DefaultPayload(object):
+class DefaultPayload(wafflehaus.base.WafflehausBase):
 
     def __init__(self, app, conf):
-        self.app = app
-        self.conf = conf
-        logname = __name__
-        self.log = logging.getLogger(conf.get('log_name', logname))
+        super(DefaultPayload, self).__init__(app, conf)
+        self.log.name = conf.get('log_name', __name__)
         self.log.info('Starting wafflehaus default payload middleware')
-        self.testing = (conf.get('testing') in
-                        (True, 'true', 't', '1', 'on', 'yes', 'y'))
         self.resources = rf.parse_resources(conf.get('resource'))
         self.defaults = pf.get_defaults(conf.get('defaults'))
 

--- a/wafflehaus/resource_filter/block_resource.py
+++ b/wafflehaus/resource_filter/block_resource.py
@@ -12,26 +12,20 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
-import logging
-
 import webob.dec
 import webob.exc
 
+import wafflehaus.base
 import wafflehaus.resource_filter as rf
 
 
-class BlockResource(object):
+class BlockResource(wafflehaus.base.WafflehausBase):
 
     def __init__(self, app, conf):
-        self.app = app
-        self.conf = conf
-        logname = __name__
-        self.log = logging.getLogger(conf.get('log_name', logname))
+        super(BlockResource, self).__init__(app, conf)
+        self.log.name = conf.get('log_name', __name__)
         self.log.info('Starting wafflehaus resource blocker middleware')
         self.user_id = conf.get('user_id')
-        self.testing = (conf.get('testing') in
-                        (True, 'true', 't', '1', 'on', 'yes', 'y'))
         self.resources = rf.parse_resources(conf.get('resource'))
 
     @webob.dec.wsgify


### PR DESCRIPTION
Refactored the common code in filters except role router

Updated readme for DNS Filter and provided support for X-Forwarded-For

Updated the readme for DNS filter to note space delimited list

Modifying strategy code to pass keys

Refactored create_patch to TestBase

changed try_context to use imported strategies instead of coded ones

moved neutron context to wafflehaus.neutron

Added test to prove that {format} wildcards work with resource filters.
