### PR TITLE
README.rst is missing from source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-sample-paste.ini
-*.rst
+include sample-paste.ini
+include *.rst


### PR DESCRIPTION
Fix MANIFEST.in syntax errors. To include/exclude files,
the following syntax should be used:

```
include pat1 pat2 ...
exclude pat1 pat2 ...
```
