### PR TITLE
Support for disabling waffles runtime

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,9 @@ Beyond the above benefits, other benefits of using wafflehaus are:
 * All of the waffles in wafflehaus are designed to be configured in the
   api-paste.ini file and thus can be distributed however you wish (puppet,
   chef, ansible)
+* It is a fairly democratic and simple way to test new openstack features and
+  designs as if many people use a particular waffle it should be added to the
+  relevant projects' feature set
 
 Finally, although Wafflehaus was intended to work with OpenStack, it is
 possible to use it in front of any WSGI compliant service.
@@ -80,6 +83,14 @@ to have the following::
 
     [WAFFLEHAUS]
     runtime_reconfigurable = True
+
+All waffles that, at a minimum, call the base's __call__ will support runtime
+enable/disable and toggling of testing with the following headers:
+
+* X_WAFFLEHAUS_CLASSNAME_ENABLED
+* X_WAFFLEHAUS_CLASSNAME_TESTING
+
+where *CLASSNAME* is the upper() of the class name of the waffle.
 
 Current Deployment Quirks
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/wafflehaus/dns_filter/whitelist.py
+++ b/wafflehaus/dns_filter/whitelist.py
@@ -35,8 +35,7 @@ class DNSWhitelist(wafflehaus.base.WafflehausBase):
         super(DNSWhitelist, self).__init__(app, conf)
         self.log.name = conf.get('log_name', __name__)
         self.log.info('Starting wafflehaus dns whitelist middleware')
-        self.ignore_forwarded = (conf.get('ignore_forwarded') in
-                                 (True, 'true', 't', '1', 'on', 'yes', 'y'))
+        self.ignore_forwarded = (conf.get('ignore_forwarded') in self.truths)
         self.whitelist = self._create_whitelist(conf.get('whitelist'))
 
     def _create_resolver(self):
@@ -74,6 +73,9 @@ class DNSWhitelist(wafflehaus.base.WafflehausBase):
     def get_remote_addr(self, request):
         return request.remote_addr
 
+    def _override(self, req):
+        super(DNSWhitelist, self)._override(req)
+
     def parse_x_forwarded_for(self, xforward):
         """It is a CSV list of IPs."""
         self.log.info("Forwarded is : " + str(xforward))
@@ -85,7 +87,9 @@ class DNSWhitelist(wafflehaus.base.WafflehausBase):
     @webob.dec.wsgify
     def __call__(self, req):
         super(DNSWhitelist, self).__call__(req)
+        self.log.info('derp %s' % self.enabled)
         if not self.enabled:
+            self.log.info("derasdf")
             return self.app
 
         if not self.whitelist:

--- a/wafflehaus/payload_filter/unset_key.py
+++ b/wafflehaus/payload_filter/unset_key.py
@@ -31,6 +31,7 @@ class DefaultPayload(wafflehaus.base.WafflehausBase):
 
     @webob.dec.wsgify
     def __call__(self, req):
+        super(DefaultPayload, self).__call__(req)
         if not self.enabled:
             return self.app
 

--- a/wafflehaus/resource_filter/block_resource.py
+++ b/wafflehaus/resource_filter/block_resource.py
@@ -30,6 +30,7 @@ class BlockResource(wafflehaus.base.WafflehausBase):
 
     @webob.dec.wsgify
     def __call__(self, req):
+        super(BlockResource, self).__call__(req)
         if not self.enabled:
             return self.app
 

--- a/wafflehaus/routers/rolerouter.py
+++ b/wafflehaus/routers/rolerouter.py
@@ -61,6 +61,7 @@ class RoleRouter(wafflehaus.base.WafflehausBase):
 
     @webob.dec.wsgify(RequestClass=webob.Request)
     def __call__(self, req):
+        super(RoleRouter, self).__call__(req)
         if not self.enabled:
             return self.app
 

--- a/wafflehaus/tests/test_dns_filter.py
+++ b/wafflehaus/tests/test_dns_filter.py
@@ -14,10 +14,14 @@
 #    under the License.
 import dns.exception
 import mock
+from oslo.config import cfg
 import webob.exc
 
 from wafflehaus.dns_filter import whitelist
 from wafflehaus import tests
+
+
+CONF = cfg.CONF
 
 
 def do_lookup(address):
@@ -97,8 +101,9 @@ class TestDNSFilter(tests.TestCase):
         m_dns_rname.side_effect = ['omg.widget.com']
 
         resp = result.__call__.request('/widget', method='POST')
-        self.assertTrue(m_dns_rname.called_once)
-        self.assertTrue(m_resolve.called_once)
+        self.assertEqual(1, m_addr.call_count)
+        self.assertEqual(1, m_dns_rname.call_count)
+        self.assertEqual(1, m_resolve.call_count)
         self.assertFalse(isinstance(resp, webob.exc.HTTPForbidden))
 
     def test_match_ok_with_forwarded_header(self):
@@ -117,8 +122,9 @@ class TestDNSFilter(tests.TestCase):
 
         resp = result.__call__.request('/widget', method='POST',
                                        headers=headers)
-        self.assertTrue(m_dns_rname.called_once)
-        self.assertTrue(m_resolve.called_once)
+        self.assertEqual(1, m_addr.call_count)
+        self.assertEqual(1, m_dns_rname.call_count)
+        self.assertEqual(1, m_resolve.call_count)
         self.assertFalse(isinstance(resp, webob.exc.HTTPForbidden))
 
 # TESTING FUNCTIONS
@@ -135,8 +141,9 @@ class TestDNSFilter(tests.TestCase):
         m_dns_rname.side_effect = ['omg.widget.com']
 
         resp = result.__call__.request('/widget', method='POST')
-        self.assertTrue(m_dns_rname.called_once)
-        self.assertTrue(m_resolve.called_once)
+        self.assertEqual(1, m_addr.call_count)
+        self.assertEqual(1, m_dns_rname.call_count)
+        self.assertEqual(1, m_resolve.call_count)
         self.assertFalse(isinstance(resp, webob.exc.HTTPForbidden))
 
     def test_no_fail_on_match_bad_address_while_testing(self):
@@ -151,8 +158,9 @@ class TestDNSFilter(tests.TestCase):
         m_dns_rname.side_effect = ['omg.widget.com']
 
         resp = result.__call__.request('/widget', method='POST')
-        self.assertTrue(m_dns_rname.called_once)
-        self.assertTrue(m_resolve.called_once)
+        self.assertEqual(1, m_addr.call_count)
+        self.assertEqual(1, m_dns_rname.call_count)
+        self.assertEqual(1, m_resolve.call_count)
         self.assertFalse(isinstance(resp, webob.exc.HTTPForbidden))
 
     def test_no_fail_match_bad_name_while_testing(self):
@@ -167,8 +175,9 @@ class TestDNSFilter(tests.TestCase):
         m_dns_rname.side_effect = ['something.bad.com']
 
         resp = result.__call__.request('/widget', method='POST')
-        self.assertTrue(m_dns_rname.called_once)
-        self.assertTrue(m_resolve.called_once)
+        self.assertEqual(1, m_addr.call_count)
+        self.assertEqual(1, m_dns_rname.call_count)
+        self.assertEqual(1, m_resolve.call_count)
         self.assertFalse(isinstance(resp, webob.exc.HTTPForbidden))
 
     def test_no_fail_match_unknown_address_while_testing(self):
@@ -183,15 +192,16 @@ class TestDNSFilter(tests.TestCase):
         m_dns_rname.side_effect = [dns.exception.DNSException]
 
         resp = result.__call__.request('/widget', method='POST')
-        self.assertTrue(m_dns_rname.called_once)
-        self.assertTrue(m_resolve.called_once)
+        self.assertEqual(1, m_addr.call_count)
+        self.assertEqual(1, m_dns_rname.call_count)
+        self.assertEqual(1, m_resolve.call_count)
         self.assertFalse(isinstance(resp, webob.exc.HTTPForbidden))
 
     def test_no_fail_no_dns_entries_while_testing(self):
         result = whitelist.filter_factory(self.testconf)(self.app)
         m_addr = self.create_patch(self.addr_path)
         resp = result.__call__.request('/widget', method='POST')
-        self.assertTrue(m_addr.called_once)
+        self.assertEqual(1, m_addr.call_count)
         self.assertFalse(isinstance(resp, webob.exc.HTTPForbidden))
 
 # END TESTING
@@ -208,8 +218,9 @@ class TestDNSFilter(tests.TestCase):
         m_dns_rname.side_effect = ['omg.widget.com']
 
         resp = result.__call__.request('/widget', method='POST')
-        self.assertTrue(m_dns_rname.called_once)
-        self.assertTrue(m_resolve.called_once)
+        self.assertEqual(1, m_addr.call_count)
+        self.assertEqual(1, m_dns_rname.call_count)
+        self.assertEqual(1, m_resolve.call_count)
         self.assertTrue(isinstance(resp, webob.exc.HTTPForbidden))
 
     def test_match_bad_address(self):
@@ -224,8 +235,9 @@ class TestDNSFilter(tests.TestCase):
         m_dns_rname.side_effect = ['omg.widget.com']
 
         resp = result.__call__.request('/widget', method='POST')
-        self.assertTrue(m_dns_rname.called_once)
-        self.assertTrue(m_resolve.called_once)
+        self.assertEqual(1, m_addr.call_count)
+        self.assertEqual(1, m_dns_rname.call_count)
+        self.assertEqual(1, m_resolve.call_count)
         self.assertTrue(isinstance(resp, webob.exc.HTTPForbidden))
 
     def test_match_bad_name(self):
@@ -240,8 +252,9 @@ class TestDNSFilter(tests.TestCase):
         m_dns_rname.side_effect = ['something.bad.com']
 
         resp = result.__call__.request('/widget', method='POST')
-        self.assertTrue(m_dns_rname.called_once)
-        self.assertTrue(m_resolve.called_once)
+        self.assertEqual(1, m_addr.call_count)
+        self.assertEqual(1, m_dns_rname.call_count)
+        self.assertEqual(1, m_resolve.call_count)
         self.assertTrue(isinstance(resp, webob.exc.HTTPForbidden))
 
     def test_match_unknown_address(self):
@@ -256,8 +269,9 @@ class TestDNSFilter(tests.TestCase):
         m_dns_rname.side_effect = [dns.exception.DNSException]
 
         resp = result.__call__.request('/widget', method='POST')
-        self.assertTrue(m_dns_rname.called_once)
-        self.assertTrue(m_resolve.called_once)
+        self.assertEqual(1, m_addr.call_count)
+        self.assertEqual(1, m_dns_rname.call_count)
+        self.assertEqual(1, m_resolve.call_count)
         self.assertTrue(isinstance(resp, webob.exc.HTTPForbidden))
 
     def test_no_dns_entries(self):
@@ -287,6 +301,27 @@ class TestDNSFilter(tests.TestCase):
 
         resp = result.__call__.request('/widget', method='POST',
                                        headers=headers)
-        self.assertTrue(m_dns_rname.called_once)
-        self.assertTrue(m_resolve.called_once)
+        self.assertEqual(1, m_addr.call_count)
+        self.assertEqual(1, m_dns_rname.call_count)
+        self.assertEqual(1, m_resolve.call_count)
         self.assertTrue(isinstance(resp, webob.exc.HTTPForbidden))
+
+    def test_runtime_overrides(self):
+        CONF.WAFFLEHAUS.runtime_reconfigurable = True
+        result = whitelist.filter_factory(self.conf)(self.app)
+        m_addr = self.create_patch(self.addr_path)
+        m_addr.return_value = self.good_ip
+
+        m_resolve = self.create_patch(self.resolver_path)
+        m_resolve.return_value = FakeResolver()
+
+        m_dns_rname = self.create_patch(self.dns_reverse)
+        m_dns_rname.side_effect = ['omg.widget.com']
+
+        headers = {'X_WAFFLEHAUS_DNSWHITELIST_ENABLED': False}
+
+        result.__call__.request('/widget', method='POST',
+                                headers=headers)
+        self.assertEqual(0, m_addr.call_count)
+        self.assertEqual(0, m_dns_rname.call_count)
+        self.assertEqual(0, m_resolve.call_count)

--- a/wafflehaus/try_context/context_filter.py
+++ b/wafflehaus/try_context/context_filter.py
@@ -56,6 +56,7 @@ class ContextFilter(wafflehaus.base.WafflehausBase):
 
     @webob.dec.wsgify
     def __call__(self, req):
+        super(ContextFilter, self).__call__(req)
         if not self.enabled:
             return self.app
 


### PR DESCRIPTION
All waffles will now support being en/disabled during runtime through a header
X_WAFFLEHAUS_<classname_uppercase>_ENABLED.

Similarly they support having themselves toggled between testing/not testing
with X_WAFFLEHAUS_<classname_uppercase>_TESTING.

Also discovered some terrible testing issues with dns_filter, and cleaned up
some of the lame true value tuples.
