### PR TITLE
Sort roles before choosing route

### DIFF
--- a/wafflehaus/routers/rolerouter.py
+++ b/wafflehaus/routers/rolerouter.py
@@ -72,7 +72,7 @@ class RoleRouter(wafflehaus.base.WafflehausBase):
             return self.routes["default"]
 
         roles = context.roles
-        for key in self.roles.keys():
+        for key in sorted(self.roles.keys()):
             if key in roles:
                 return self.routes[self.roles[key]]
 


### PR DESCRIPTION
RM9700

Sort the auth roles defined in the rolerouter config before choosing the matching route.
