### PR TITLE
Waffle logs will not error; str(*)

### DIFF
--- a/wafflehaus/log_filters/req_resp.py
+++ b/wafflehaus/log_filters/req_resp.py
@@ -83,10 +83,14 @@ class RequestResponseLogger(wafflehaus.base.WafflehausBase):
         contents.append("%s%s" % (req.path, qs))
         contents.append(context_info['request'])
         contents.append(context_info['tenant'])
+
         if self.do_detail_logs:
             contents.append(id)
 
-        log_str = self.separator.join(contents)
+        """Turn everything into a string."""
+        string_contents = [str(c) for c in contents]
+
+        log_str = self.separator.join(string_contents)
         self.log.info(log_str)
         if resp.status_int >= self.detail_level and self.do_detail_logs:
             self._log_detail_request(id, req, resp, delta, log_time)
@@ -135,7 +139,10 @@ class RequestResponseLogger(wafflehaus.base.WafflehausBase):
         difference = (time.time() - start)
 
         log_time = time.strftime("%Y-%m-%d %H:%M")
-        self._log_simple_request(req, resp, difference, log_time)
+        try:
+            self._log_simple_request(req, resp, difference, log_time)
+        except Exception as e:
+            self.log("Failed to log due to exception: %s" % e)
 
         if resp is None:
             return self.app


### PR DESCRIPTION
JIRA:NCP-1800

Previously log_filters would raise exceptions due to weirdness in the
responses -> Wrap logging into a catch all and never raise

Ppeviously log_filters would barf on non string things when joining ->
change everything in the response to a string before joining