### PR TITLE
Changing response code on POST ip_addresses

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 # Packages needed for dev testing
-distribute>=0.6.24
 mock
 coverage
 discover

--- a/wafflehaus/edit_response/README.rst
+++ b/wafflehaus/edit_response/README.rst
@@ -65,6 +65,28 @@ Another element can be allowed if the criteria is expanded.
 It is also possible to drop if the criteria is met by using drop_if instead of
 keep_if.
 
+Using http_status_code->replace_if
+~~~~~~~~~~~~~
+
+This can be used to replace an http status code with a different code.
+
+::
+
+    [filter:edit_response]
+    paste.filter_factory = wafflehaus.edit_response:filter_factory
+    enabled = true
+    filters = http_filter
+    http_filter_resource = POST /v2.0/resource
+    http_filter_key = http_status_code
+    http_filter_value = replace_if:200:201
+
+In the above example, a specific request type may return a 200 where it should
+return a 201. replace_if:<status_code_match>:<status_code_to_replace> will
+verify that the actual response status returned from the target resource was a 
+200 before it will replace that http status code with a 201.
+
+Each request type for a given resource must have its own filter.
+
 Use Case
 ~~~~~~~~
 

--- a/wafflehaus/edit_response/__init__.py
+++ b/wafflehaus/edit_response/__init__.py
@@ -109,6 +109,14 @@ class EditResponse(WafflehausBase):
         try:
             new_body = resp.json
             new_body = walk_keys(new_body)
+            if 'http_status_code' in resource['key']:
+                resource_val = resource['value']
+                if resource_val.startswith('replace_if'):
+                    (status_chk, status_repl) = resource_val.split(':')[1:3]
+                    if str(resp.status_code) == status_chk:
+                        self.log.debug('Replacing http status code "{0}" with '
+                                       '"{1}"'.format(status_chk, status_repl))
+                        resp.status_code = int(status_repl)
             resp.body = json.dumps(new_body)
         except JSONDecodeError:
             pass

--- a/wafflehaus/tests/test_edit_response.py
+++ b/wafflehaus/tests/test_edit_response.py
@@ -236,3 +236,71 @@ class TestEditResponse(tests.TestCase):
         resp = test_filter(webob.Request.blank("/sauce/None", method="GET"))
 
         self.assertEqual(resp.body, app_body)
+
+    def test_http_status_replace_get(self):
+        app_body = {"garbage": {"garbage": "here"}}
+
+        test_status = {"enabled": "true",
+                       "filters": "httpget",
+                       "httpget_resource": "GET /sauce",
+                       "httpget_key": "http_status_code",
+                       "httpget_value": "replace_if:200:201"}
+
+        @webob.dec.wsgify
+        def app(req):
+            return webob.Response(body=json.dumps(app_body), status=200)
+        test_filter = edit_response.filter_factory(test_status)(app)
+
+        resp = test_filter(webob.Request.blank("/sauce", method="GET"))
+        self.assertEqual(resp.status_code, 201, resp)
+
+    def test_http_status_replace_post(self):
+        app_body = {"garbage": {"garbage": "here"}}
+
+        test_status = {"enabled": "true",
+                       "filters": "httppost",
+                       "httppost_resource": "POST /sauce",
+                       "httppost_key": "http_status_code",
+                       "httppost_value": "replace_if:200:201"}
+
+        @webob.dec.wsgify
+        def app(req):
+            return webob.Response(body=json.dumps(app_body), status=200)
+        test_filter = edit_response.filter_factory(test_status)(app)
+
+        resp = test_filter(webob.Request.blank("/sauce", method="POST"))
+        self.assertEqual(resp.status_code, 201, resp)
+
+    def test_http_status_replace_put(self):
+        app_body = {"garbage": {"garbage": "here"}}
+
+        test_status = {"enabled": "true",
+                       "filters": "httpput",
+                       "httpput_resource": "PUT /sauce/{id}",
+                       "httpput_key": "http_status_code",
+                       "httpput_value": "replace_if:200:201"}
+
+        @webob.dec.wsgify
+        def app(req):
+            return webob.Response(body=json.dumps(app_body), status=200)
+        test_filter = edit_response.filter_factory(test_status)(app)
+
+        resp = test_filter(webob.Request.blank("/sauce/id", method="PUT"))
+        self.assertEqual(resp.status_code, 201, resp)
+
+    def test_http_status_replace_delete(self):
+        app_body = {"garbage": {"garbage": "here"}}
+
+        test_status = {"enabled": "true",
+                       "filters": "httpdelete",
+                       "httpdelete_resource": "DELETE /sauce/{id}",
+                       "httpdelete_key": "http_status_code",
+                       "httpdelete_value": "replace_if:200:201"}
+
+        @webob.dec.wsgify
+        def app(req):
+            return webob.Response(body=json.dumps(app_body), status=200)
+        test_filter = edit_response.filter_factory(test_status)(app)
+
+        resp = test_filter(webob.Request.blank("/sauce/id", method="DELETE"))
+        self.assertEqual(resp.status_code, 201, resp)


### PR DESCRIPTION
JIRA:NCP-1577

Added functionality in edit_response waffle to modify an http response
code if it matches in the api-paste.ini. This is specific to request
type, so individual filters would have to be created for POST/PUT/DELETE