### PR TITLE
Removed pip's --use-mirrors option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.7"
 install:
-  - pip install -r requirements.txt -r test-requirements.txt . --use-mirrors
+  - pip install -r requirements.txt -r test-requirements.txt .
 before_script:
   - "flake8 --show-source --builtins=_ wafflehaus"
 script:


### PR DESCRIPTION
--use-mirrors was deprecated according to https://pip.pypa.io/en/stable/news/